### PR TITLE
Add version in usage information + command to check gzipped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ You can also use ``grabix`` to extract random lines from the file
 
 	# extract 10 randome lines from the file using reservoir sampling
 	grabix random simrep.chr1.bed.gz 10
+    
+Is a gzipped file bgzipped?
+
+    grabix check simrep.chr1.bed.gz

--- a/grabix.cpp
+++ b/grabix.cpp
@@ -37,6 +37,9 @@ int usage()
     cout << endl;
     cout << "       # extract the 100 random lines." << endl;
     cout << "       grabix random big.vcf.gz 100" << endl;
+    cout << endl;
+    cout << "       # Is the file bgzipped?" << endl;
+    cout << "       grabix check big.vcf.gz" << endl;
     cout << "version: " << VERSION << "\n";
     cout << endl;
     return EXIT_SUCCESS;
@@ -336,6 +339,10 @@ int main (int argc, char **argv)
         {
             size_t N = atoi(argv[3]);
             random(bgzf_file, N);
+        }
+        else if (sub_command == "check")
+        {
+          cout << ((bgzf_is_bgzf(bgzf_file.c_str()) == 1) ? "yes" : "no") << "\n";
         }
     }
 


### PR DESCRIPTION
Aaron;
This small patch adds versioning for grabix into the usage. This allows me to check the version with CloudBioLinux and ensure we've got the latest and greatest.

I'm hoping to use this for indexing into bgzipped FASTQ files and need the installed grabix to have the no-header initialization fixes from a couple of weeks ago.

On a semi-related topic, do you know of any good ways to apply this approach to indexing BAMs to split into parts, rather than by location? Is that in your plans for grabix? (whoops, just saw #2)

I also added a small utility to check if a file is bgzipped, allowing defensive programming to distinguish gzipped and bgzipped inputs.
