### PR TITLE
added 'size' subcommand to get the number of lines in the file

### DIFF
--- a/grabix.cpp
+++ b/grabix.cpp
@@ -28,6 +28,9 @@ int usage()
     cout << endl;
     cout << "       # Is the file bgzipped?" << endl;
     cout << "       grabix check big.vcf.gz" << endl;
+    cout << endl;
+    cout << "       # get total number of lines in the file (minus the header)." << endl;
+    cout << "       grabix size big.vcf.gz" << endl;
     cout << "version: " << VERSION << "\n";
     cout << endl;
     return EXIT_SUCCESS;
@@ -304,4 +307,15 @@ int random(string bgzf_file, uint64_t K)
 
     }
     return EXIT_SUCCESS;
+}
+
+/*
+Return the total number of records in the index.
+*/
+int size(string bgzf_file)
+{
+  index_info index;
+  load_index(bgzf_file, index);
+
+  return index.num_lines;
 }

--- a/grabix.h
+++ b/grabix.h
@@ -45,3 +45,8 @@ int grab(string bgzf_file, int64_t from_line, int64_t to_line);
 Extract K random lines from file using reservoir sampling
 */
 int random(string bgzf_file, uint64_t K);
+
+/*
+Return the total number of records in the index.
+*/
+int size(string bgzf_file);

--- a/grabix_main.cpp
+++ b/grabix_main.cpp
@@ -38,6 +38,10 @@ int main (int argc, char **argv)
         {
           cout << ((bgzf_is_bgzf(bgzf_file.c_str()) == 1) ? "yes" : "no") << "\n";
         }
+        else if (sub_command == "size")
+        {
+          cout << size(bgzf_file) << "\n";
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
This is needed for, among other things, splitting a file into chunks for parallel processing.