### PR TITLE
closes #21

### DIFF
--- a/grabix.cpp
+++ b/grabix.cpp
@@ -98,13 +98,14 @@ int create_grabix_index(string bgzf_file)
         // grab the next line and store the offset
         eof = bgzf_getline_counting(bgzf_fp);
         offset = bgzf_tell (bgzf_fp);
+        chunk_count++;
         // stop if we have encountered an empty line
         if (eof)
         {
             if (bgzf_check_EOF(bgzf_fp) == 1) {
                 if (offset > prev_offset) {
                     total_lines++;
-					//prev_offset = offset;
+                    prev_offset = offset;
                 }
                 break;
             }
@@ -115,7 +116,6 @@ int create_grabix_index(string bgzf_file)
             chunk_positions.push_back(prev_offset);
             chunk_count = 0;
         }
-        chunk_count++;
         total_lines++;
         prev_offset = offset;
     }

--- a/grabix.h
+++ b/grabix.h
@@ -7,7 +7,7 @@ using namespace std;
 #include "bgzf.h"
 
 
-#define VERSION "0.1.5"
+#define VERSION "0.1.6"
 // we only want to store the offset for every 10000th
 // line. otherwise, were we to store the position of every
 // line in the file, the index could become very large for

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,19 @@
 make
 
+FQ=test.cnt.gz
+rm -f ${FQ}{,.gbi}
+
+lines=50000
+python tests/make-test-fastq.py $lines | bgzip -c > $FQ
+./grabix index $FQ
+python tests/test-fastq.py $FQ
+a=$(grabix grab test.cnt.gz $(($lines * 4)))
+b=$(zless $FQ | tail -1)
+if [[ "$a" != "$b" ]]; then
+	echo FAIL last record
+fi
+rm -f ${FQ}{,.gbi}
+
 for V in  \
 	test.PLs.vcf \
 	test.auto_dom.no_parents.2.vcf \

--- a/tests/make-test-fastq.py
+++ b/tests/make-test-fastq.py
@@ -1,0 +1,9 @@
+import sys
+n = int(sys.argv[1]) + 1
+for i in range(1, n):
+    s = str(i) + "ACTG"
+    print "@read_%i" % i
+    seq = "".join([s] * 20)[:100]
+    print seq
+    print "+"
+    print seq

--- a/tests/test-fastq.py
+++ b/tests/test-fastq.py
@@ -1,0 +1,44 @@
+import sys
+import subprocess
+import gzip
+
+f = sys.argv[1]
+lines = ["EMPTY"] + [x.strip() for x in gzip.open(f).readlines()]
+
+print "checking indexing at bounds:"
+
+def check(gzname, start, end=None):
+    run = subprocess.check_output
+    exp = lines[start:start+1] if end is None else lines[start:end + 1]
+    obs = run("./grabix grab %s %d" % (gzname, start), shell=True) if end is None \
+            else run("./grabix grab %s %d %d" % (gzname, start, end), shell=True)
+    obs = [x.strip() for x in obs.strip().split("\n")]
+    sys.stdout.write(".")
+    sys.stdout.flush()
+    assert exp == obs, (exp, obs)
+    if start % 4 == 1:
+        assert obs[0][0] == "@"
+    else:
+        assert obs[0][0] != "@"
+
+for i in range(9990, 10010):
+    check(f, i)
+    check(f, i, i + 11)
+    check(f, i, i + 101)
+
+for i in range(19990, 20010):
+    check(f, i)
+    check(f, i, i + 1)
+    check(f, i, i + 4)
+
+for i in range(1, 200):
+    check(f, i)
+    check(f, i, i + 1)
+    check(f, i, i + 4)
+
+n = len(lines)
+
+check(f, n - 1)
+
+print("\nPASS")
+


### PR DESCRIPTION
commit 8d81fed fix one off-by-1 and introduced another. The source
was moving the chunk_count below the block of code. This maintains
the fix from 8d81fed and replaces the chunk count. It also adds a
large number of functional tests via a python script that creates
and tests grabix grab. Thanks to @schelhorn for a very clear bug
desription.
This also bumps the version to 0.1.6