### PR TITLE
Make grabix compile again

### DIFF
--- a/grabix.cpp
+++ b/grabix.cpp
@@ -78,7 +78,7 @@ int create_grabix_index(string bgzf_file)
 
     int status;
     kstring_t *line = new kstring_t;
-    line->s = '\0';
+    line->s = (char *) 0;
     line->l = 0;
     line->m = 0;
 
@@ -210,7 +210,7 @@ int grab(string bgzf_file, int64_t from_line, int64_t to_line)
         // dump the header if there is one
         int status;
         kstring_t *line = new kstring_t;
-        line->s = '\0';
+        line->s = (char *) 0;
         line->l = 0;
         line->m = 0;
 
@@ -282,7 +282,7 @@ int random(string bgzf_file, uint64_t K)
         vector<string> sample;
         int status;
         kstring_t *line = new kstring_t;
-        line->s = '\0';
+        line->s = (char *) 0;
         line->l = 0;
         line->m = 0;
 


### PR DESCRIPTION
As proposed in https://github.com/arq5x/grabix/issues/38.

'\0' is still the character terminating strings in C, but line->s is a pointer to a string, not the string itself. I added the cast to make the semantics clearer. On a sidenote, the kstring gets dynamically allocated but never freed. This is small memory leak. More importantly, I am a bit uncertain about who is freeing line->s . So, should there ever be an issue with memory, this may be worth a second look.